### PR TITLE
Spawn liri-shell-helper

### DIFF
--- a/data/systemd/liri-session.target
+++ b/data/systemd/liri-session.target
@@ -1,5 +1,5 @@
 [Unit]
 Description=Liri graphical user session
 BindsTo=graphical-session.target
-Requires=liri-session-pre.target liri-shell.target
-After=liri-session-pre.target liri-shell.target
+Requires=liri-session-pre.target liri-shell.target liri-shell-helper.target
+After=liri-session-pre.target liri-shell.target liri-shell-helper.target

--- a/src/plugins/session/shell/plugin.h
+++ b/src/plugins/session/shell/plugin.h
@@ -51,8 +51,11 @@ private:
     int m_watchDogCounter = 3;
     QEventLoop *m_loop = nullptr;
     QDBusServiceWatcher *m_serviceWatcher = nullptr;
-    QProcess *m_process = nullptr;
+    QProcess *m_serverProcess = nullptr;
+    QProcess *m_helperProcess = nullptr;
     bool m_stopping = false;
+
+    void startShellHelper();
 
 private Q_SLOTS:
     void handleServiceRegistered(const QString &serviceName);


### PR DESCRIPTION
This is the central place for spawning the session, so we want to
spawn liri-shell-helper from here too, instead of having the
compositor do it.

Closes: #7